### PR TITLE
Format download count number like in BarChart with thousands separator

### DIFF
--- a/src/Graph/PieChart.js
+++ b/src/Graph/PieChart.js
@@ -24,7 +24,8 @@ export default class PieChart extends Component {
             },
             tooltip: {
                 formatter: function () {
-                    return this.point.name + '<b> ' + this.point.percentage.toFixed(2) + '% </b><br/><b> ' + this.y + '</b> downloads';
+                    let nbDownloads = Highcharts.numberFormat(this.y, 0, '.', ' ');
+                    return this.point.name + '<b> ' + this.point.percentage.toFixed(2) + '% </b><br/><b> ' + nbDownloads + '</b> downloads';
                 }
             },
             plotOptions: {


### PR DESCRIPTION
This PR is a suggestion to use the same number format in PieChart than in BarChat with thousands separator.

'### ### ### ###' ==> 123 456 789

Easier to read :eyes: 

