### PR TITLE
Fix a problem with css-dev-only-do-not-override (antd)

### DIFF
--- a/src/Components/NavigationMenu/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/Components/NavigationMenu/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NavigationMenu component > renders correctly /download path 1`] = `
 <div>
   <ul
-    class="ant-menu ant-menu-root ant-menu-inline ant-menu-light css-dev-only-do-not-override-1vr7spz"
+    class="ant-menu ant-menu-root ant-menu-inline ant-menu-light"
     data-menu-list="true"
     role="menu"
     style="height: 100%; border-right: 0; margin-top: 20px;"
@@ -83,7 +83,7 @@ exports[`NavigationMenu component > renders correctly /download path 1`] = `
 exports[`NavigationMenu component > renders correctly /trends path 1`] = `
 <div>
   <ul
-    class="ant-menu ant-menu-root ant-menu-inline ant-menu-light css-dev-only-do-not-override-1vr7spz"
+    class="ant-menu ant-menu-root ant-menu-inline ant-menu-light"
     data-menu-list="true"
     role="menu"
     style="height: 100%; border-right: 0; margin-top: 20px;"

--- a/src/Components/NavigationMenu/__tests__/index.test.tsx
+++ b/src/Components/NavigationMenu/__tests__/index.test.tsx
@@ -4,8 +4,6 @@ import { vi, describe, expect, test } from 'vitest'
 import NavigationMenu from '../index';
 import { useLocation } from 'react-router-dom';
 
-vi.mock('react-router-dom');
-
 describe('NavigationMenu component', () => {
     test('renders correctly /download path', async() => {
         vi.mocked(useLocation).mockReturnValue({path: '/download'});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     },
     "include": [
         "**/*.{ts,tsx,mdx}",
-        "vitest.config.ts",
-        "vitest-setup.ts"
+        "vitest-setup.ts",
+        "vitest.config.ts"
     ]
 }

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,32 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import fs from 'fs/promises';
+import { vi } from 'vitest'
 
-export default defineConfig({
-  esbuild: {
-    loader: "jsx",
-    include: /src\/.*\.jsx?$/,
-    exclude: [],
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      plugins: [
-        {
-          name: "load-js-files-as-jsx",
-          setup(build) {
-            build.onLoad({ filter: /src\\.*\.js$/ }, async (args) => ({ // i modified the regex here
-              loader: "jsx",
-              contents: await fs.readFile(args.path, "utf8"),
-            }));
-          },
-        },
-      ],
-    },
-  },
-  plugins: [react()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './vitest-setup.ts'
-  }
-})
+// mock router for 'useParams'
+vi.mock('react-router-dom');
+
+vi.mock('antd', async () => {
+  const antd = await vi.importActual('antd');
+  // @ts-expect-error importActualの型付けをしていない
+  antd.theme.defaultConfig.hashed = false;
+  return antd;
+});


### PR DESCRIPTION
This PR fix a problem with the library antd that generates strange css classnames.

Review configuration of Vitest