### PR TITLE
Add a new level in drilldown by Package Type

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ import ErrorBoundary from './ErrorBoundary'
 import { MenuFoldOutlined, MenuUnfoldOutlined } from '@ant-design/icons'
 
 AccessibilityModule(Highcharts)
-Highcharts.AST.allowedAttributes.push('rel');
+Highcharts.AST.allowedAttributes.push('rel')
 
 const { Header, Content, Sider } = Layout
 

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import ErrorBoundary from './ErrorBoundary'
 import { MenuFoldOutlined, MenuUnfoldOutlined } from '@ant-design/icons'
 
 AccessibilityModule(Highcharts)
+Highcharts.AST.allowedAttributes.push('rel');
 
 const { Header, Content, Sider } = Layout
 

--- a/src/Graph/ColumnDrilldown.tsx
+++ b/src/Graph/ColumnDrilldown.tsx
@@ -4,7 +4,7 @@ import HighchartsReact from 'highcharts-react-official';
 import drilldown from 'highcharts/modules/drilldown';
 import './Graph.css';
 import { api } from '../api';
-import {splitDrilldownSeriesByArchAndOs} from '../utils'
+import {splitDrilldownSeriesByArtifacts} from '../utils'
 
 drilldown(Highcharts);
 
@@ -77,24 +77,24 @@ export default class ColumnDrilldown extends Component<ColumnDrilldownProps, Col
             };
           });
 
-          const r = splitDrilldownSeriesByArchAndOs(secondLevelDrilldownSeriesData);
+          const r = splitDrilldownSeriesByArtifacts(secondLevelDrilldownSeriesData);
           archLevelDrilldownSeries.push({
             name: apiDataKey,
             id: apiDataKey,
-            data: Object.keys(r.arch).sort((a, b) => a.localeCompare(b)).map(oneArch => {
+            data: Object.keys(r.artifacts).sort((a, b) => a.localeCompare(b)).map(val => {
               return {
-                name: oneArch,
-                y: r.arch[oneArch].data.reduce((a, b) => a + b.y || 0, 0),
-                drilldown: `${apiDataKey}-${oneArch}`
+                name: val,
+                y: r.artifacts[val].data.reduce((a, b) => a + b.y || 0, 0),
+                drilldown: `${apiDataKey}-${val}`
               }
             })
           });
 
-          Object.keys(r.arch).forEach(oneArch => {
+          Object.keys(r.artifacts).forEach(val => {
             archLevelDrilldownSeries.push({
-              name: `${apiDataKey}-${oneArch}`,
-              id: `${apiDataKey}-${oneArch}`,
-              data: r.arch[oneArch].data.sort((a, b) => a.name.localeCompare(b.name))
+              name: `${apiDataKey}-${val}`,
+              id: `${apiDataKey}-${val}`,
+              data: r.artifacts[val].data.sort((a, b) => a.name.localeCompare(b.name))
             });
           });
 

--- a/src/Graph/ColumnDrilldown.tsx
+++ b/src/Graph/ColumnDrilldown.tsx
@@ -81,7 +81,7 @@ export default class ColumnDrilldown extends Component<ColumnDrilldownProps, Col
           archLevelDrilldownSeries.push({
             name: apiDataKey,
             id: apiDataKey,
-            data: Object.keys(r.arch).map(oneArch => {
+            data: Object.keys(r.arch).sort((a, b) => a.localeCompare(b)).map(oneArch => {
               return {
                 name: oneArch,
                 y: r.arch[oneArch].data.reduce((a, b) => a + b.y || 0, 0),
@@ -94,7 +94,7 @@ export default class ColumnDrilldown extends Component<ColumnDrilldownProps, Col
             archLevelDrilldownSeries.push({
               name: `${apiDataKey}-${oneArch}`,
               id: `${apiDataKey}-${oneArch}`,
-              data: r.arch[oneArch].data
+              data: r.arch[oneArch].data.sort((a, b) => a.name.localeCompare(b.name))
             });
           });
 

--- a/src/Graph/ColumnDrilldown.tsx
+++ b/src/Graph/ColumnDrilldown.tsx
@@ -84,7 +84,7 @@ export default class ColumnDrilldown extends Component<ColumnDrilldownProps, Col
             data: Object.keys(r.arch).map(oneArch => {
               return {
                 name: oneArch,
-                y: 2000,
+                y: r.arch[oneArch].data.reduce((a, b) => a + b.y || 0, 0),
                 drilldown: `${apiDataKey}-${oneArch}`
               }
             })

--- a/src/Graph/ColumnDrilldown.tsx
+++ b/src/Graph/ColumnDrilldown.tsx
@@ -4,7 +4,7 @@ import HighchartsReact from 'highcharts-react-official';
 import drilldown from 'highcharts/modules/drilldown';
 import './Graph.css';
 import { api } from '../api';
-import {toSecondAndThirdLevels} from '../utils'
+import {splitDrilldownSeriesByArchAndOs} from '../utils'
 
 drilldown(Highcharts);
 
@@ -77,7 +77,7 @@ export default class ColumnDrilldown extends Component<ColumnDrilldownProps, Col
             };
           });
 
-          const r = toSecondAndThirdLevels(secondLevelDrilldownSeriesData);
+          const r = splitDrilldownSeriesByArchAndOs(secondLevelDrilldownSeriesData);
           archLevelDrilldownSeries.push({
             name: apiDataKey,
             id: apiDataKey,
@@ -121,8 +121,6 @@ export default class ColumnDrilldown extends Component<ColumnDrilldownProps, Col
       });
       
       const seriesData = (await Promise.all(seriesDataPromises)).filter(Boolean) as DrilldownData[];
-
-      console.log(archLevelDrilldownSeries)
 
       drilldownSeries.push(...archLevelDrilldownSeries)
       this.setState({

--- a/src/Graph/LineChart.tsx
+++ b/src/Graph/LineChart.tsx
@@ -31,12 +31,17 @@ const LineChart: FC<LineChartProps> = ({ series, categories, name }) => {
         text: 'Downloads',
       },
     },
+    tooltip: {
+      headerFormat: '<span style="font-size:10px">{point.key}</span><table>',
+      footerFormat: '</table>',
+      shared: true,
+      useHTML: true
+    },
     plotOptions: {
       line: {
         dataLabels: {
           enabled: true,
         },
-        enableMouseTracking: false,
       },
     },
     series,

--- a/src/Graph/__tests__/Download.test.tsx
+++ b/src/Graph/__tests__/Download.test.tsx
@@ -39,10 +39,10 @@ api.downloads = vi.fn().mockImplementation(() => {
 describe('Download component', () => {
     test('renders correctly', async () => {
         let getByText;
-        let queryAllByLabelText;
+        let queryAllByText;
 
         await act(async () => {
-            ({ getByText, queryAllByLabelText } = render(
+            ({ getByText, queryAllByText } = render(
                 <Download />
             ));
             setTimeout(() => { }, delay)
@@ -51,16 +51,17 @@ describe('Download component', () => {
         expect(getByText('Adoptium Download Stats')).toBeInTheDocument();
         expect(getByText('233 144 070')).toBeInTheDocument();
 
-        expect(queryAllByLabelText('Total Downloads').length).toBe(2);
+        expect(queryAllByText('Total Downloads', {selector: 'text'}).length).toBe(3);
         expect(getByText('72 333 402')).toBeInTheDocument();
         expect(getByText('160 810 668')).toBeInTheDocument();
         expect(getByText('233 144 070')).toBeInTheDocument();
 
-        expect(queryAllByLabelText('Github Downloads').length).toBe(1);
-
+        expect(queryAllByText('Github Downloads', {selector: 'text'}).length).toBe(3);
         expect(getByText('39 821 217')).toBeInTheDocument();
         expect(getByText('48 300 842')).toBeInTheDocument();
         expect(getByText('45 342 098')).toBeInTheDocument();
         expect(getByText('594 778')).toBeInTheDocument();
+
+        expect(queryAllByText('JDK Versions', {selector: 'text'}).length).toBe(1);
     });
 });

--- a/src/Graph/__tests__/Trends.test.tsx
+++ b/src/Graph/__tests__/Trends.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { act, render } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest'
+import Trends from '../Trends'
+import { api } from '../../api'
+
+// NOTE: Use a delay to avoid diff with rendering animation
+// https://github.com/highcharts/highcharts/issues/14328
+
+const delay = 2000;
+
+const mock_tracking_data = 
+    [
+        {
+            "daily": 391783,
+            "date": "2023-09-23T22:31:18Z",
+            "total": 232137708
+        },
+        {
+            "daily": 357992,
+            "date": "2023-09-24T23:29:09Z",
+            "total": 232509871
+        },
+        {
+            "daily": 622526,
+            "date": "2023-09-25T23:56:17Z",
+            "total": 233144070
+        },
+        {
+            "daily": 604188,
+            "date": "2023-09-27T00:50:24Z",
+            "total": 233770916
+        }
+    ];
+
+const mock_monthly_data = [
+    {
+        "month": "2023-03",
+        "monthly": 12979542,
+        "total": 141309172
+    },
+    {
+        "month": "2023-04",
+        "monthly": 13901768,
+        "total": 155210940
+    },
+    {
+        "month": "2023-05",
+        "monthly": 14989924,
+        "total": 170200864
+    },
+    {
+        "month": "2023-06",
+        "monthly": 13907241,
+        "total": 184108105
+    },
+    {
+        "month": "2023-07",
+        "monthly": 18093361,
+        "total": 202201466
+    },
+    {
+        "month": "2023-08",
+        "monthly": 16954788,
+        "total": 219156254
+    }
+]
+
+api.tracking = vi.fn().mockImplementation(() => {
+    return mock_tracking_data;
+});
+api.monthly = vi.fn().mockImplementation(() => {
+    return mock_monthly_data;
+});
+
+describe('Trends component', () => {
+    test('renders correctly', async () => {
+        let queryAllByText;
+
+        await act(async () => {
+            ({ queryAllByText } = render(
+                <Trends />
+            ));
+            setTimeout(() => { }, delay)
+        });
+
+        expect(queryAllByText('Tracking Trends', {selector: 'text'}).length).toBe(1);
+        expect(queryAllByText('Monthly Trends', {selector: 'text'}).length).toBe(2);
+    });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,43 +31,7 @@ export const formatNum = number => {
   return number.toLocaleString(navigator.language)
 }
 
-export const secondLevelDrilldownSeriesDataToThirdLevel = (data) => {
-  const mArch = new Map();
-  const mOs = new Map();
-
-  mArch.set('sources', []);
-  mOs.set('sources', []);
-
-  data.forEach((slddsd) => {
-    const tokens = slddsd.name.split('_');
-    // console.info("what = " + tokens[0]);
-    // console.info("arch = " + tokens[1]);
-    // console.info("os = " + tokens[2]);
-    // console.info("hotspot = " + tokens[3]);
-    // console.info("version = " + tokens[4]);
-
-    if(tokens.length === 3 && tokens[0].endsWith("sources")) {
-      mArch.get('sources').push(slddsd);
-      mOs.get('sources').push(slddsd);
-    } else if(tokens.length >= 5) {
-      if(!mArch.has(tokens[1])) mArch.set(tokens[1], []);
-      mArch.get(tokens[1]).push(slddsd);
-
-      if(!mOs.has(tokens[2])) mOs.set(tokens[2], []);
-      mOs.get(tokens[2]).push(slddsd);
-    }
-  });
-
-  if(mArch.get('sources').length === 0) mArch.delete('sources');
-  if(mOs.get('sources').length === 0) mOs.delete('sources');
-
-  return {
-    arch: Object.fromEntries(mArch),
-    os: Object.fromEntries(mOs)
-  };
-}
-
-export const toSecondAndThirdLevels = (data) => {
+export const splitDrilldownSeriesByArchAndOs = (data) => {
   const mArch = new Map();
   const mOs = new Map();
 
@@ -82,11 +46,14 @@ export const toSecondAndThirdLevels = (data) => {
     // console.info("hotspot = " + tokens[3]);
     // console.info("version = " + tokens[4]);
 
+    slddsd['name'] = getFormattedName(tokens);
+
     if(tokens.length === 3 && tokens[0].endsWith("sources")) {
       mArch.get('sources').data.push(slddsd);
       mOs.get('sources').data.push(slddsd);
     } else if(tokens.length >= 5) {
       if(!mArch.has(tokens[1])) mArch.set(tokens[1], {name: tokens[1], id: tokens[1], data: []});
+
       mArch.get(tokens[1]).data.push(slddsd);
 
       if(!mOs.has(tokens[2])) mOs.set(tokens[2], {name: tokens[1], id: tokens[1], data: []});
@@ -101,4 +68,12 @@ export const toSecondAndThirdLevels = (data) => {
     arch: Object.fromEntries(mArch),
     os: Object.fromEntries(mOs)
   };
+}
+
+const getFormattedName = (tokens) => {
+  if(tokens.length === 3 && tokens[0].endsWith("sources")) return "sources";
+  else if(tokens.length >= 5) {
+    const afterCarret = tokens[0].slice(tokens[0].indexOf('-') + 1);
+    return `${afterCarret} ${tokens[2]}`}
+  else return tokens.join('_')    
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,54 +31,50 @@ export const formatNum = number => {
   return number.toLocaleString(navigator.language)
 }
 
-export const splitDrilldownSeriesByArchAndOs = (data) => {
-  const mArch = new Map()
-  const mOs = new Map()
+export const splitDrilldownSeriesByArtifacts = (data) => {
+  const mArtifacts = new Map()
 
-  mArch.set('sources', { name: 'Sources', id: 'sources', data: [] })
-  mOs.set('sources', { name: 'Sources', id: 'sources', data: [] })
+  data.forEach((entry) => {
+    const { artifact, name } = getArtifactAndFormattedName(entry)
 
-  data.forEach((slddsd) => {
-    const tokens = slddsd.name.split('_')
-    // console.info("what = " + tokens[0]);
-    // console.info("arch = " + tokens[1]);
-    // console.info("os = " + tokens[2]);
-    // console.info("hotspot = " + tokens[3]);
-    // console.info("version = " + tokens[4]);
+    if (artifact !== undefined && name !== undefined) {
+      // add a name field
+      entry.name = name
 
-    slddsd.name = getFormattedName(tokens)
+      if (!mArtifacts.has(artifact)) mArtifacts.set(artifact, { name: artifact, id: artifact, data: [] })
 
-    if (tokens.length === 3 && tokens[0].endsWith('sources')) {
-      mArch.get('sources').data.push(slddsd)
-      mOs.get('sources').data.push(slddsd)
-    } else if (tokens.length >= 5) {
-      if (!mArch.has(tokens[1])) mArch.set(tokens[1], { name: tokens[1], id: tokens[1], data: [] })
-
-      mArch.get(tokens[1]).data.push(slddsd)
-
-      if (!mOs.has(tokens[2])) mOs.set(tokens[2], { name: tokens[1], id: tokens[1], data: [] })
-      mOs.get(tokens[2]).data.push(slddsd)
+      mArtifacts.get(artifact).data.push(entry)
     }
   })
 
-  if (mArch.get('sources').data.length === 0) mArch.delete('sources')
-  if (mOs.get('sources').data.length === 0) mOs.delete('sources')
-
   return {
-    arch: Object.fromEntries(mArch),
-    os: Object.fromEntries(mOs)
+    artifacts: Object.fromEntries(mArtifacts)
   }
 }
 
-const getFormattedName = (tokens) => {
-  if (tokens.length === 3 && tokens[0].endsWith('sources')) return 'sources'
-  else if (tokens.length >= 5) {
-    let afterCarret = tokens[0].slice(tokens[0].indexOf('-') + 1)
-    if (afterCarret === 'jre') afterCarret = 'JRE'
-    else if (afterCarret === 'jdk') afterCarret = 'JDK'
+/**
+ * what = tokens[0]
+ * arch = tokens[1]
+ * os =  tokens[2]
+ * hotspot = tokens[3]
+ * version = tokens[4]
+ */
+const getArtifactAndFormattedName = (entry) => {
+  const tokens = entry.name.split('_')
 
-    return `${capitalizeFirst(tokens[2])} (${capitalizeFirst(afterCarret)})`
-  } else return tokens.join('_')
+  if (tokens.length > 0 && tokens[0].endsWith('sources')) {
+    return { artifact: 'sources', name: 'sources' }
+  } else if (tokens.length >= 5) {
+    const artifact = tokens[0].slice(tokens[0].indexOf('-') + 1)
+    const name = entry.name.endsWith('.msi')
+      ? `${capitalizeFirst(tokens[2])} (${capitalizeFirst(tokens[1])} / installer)`
+      : `${capitalizeFirst(tokens[2])} (${capitalizeFirst(tokens[1])})`
+
+    return { artifact, name }
+  } else {
+    // this should not append
+    return { artifact: undefined, name: undefined }
+  }
 }
 
 const capitalizeFirst = (text) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,3 +30,75 @@ export const parse = query => {
 export const formatNum = number => {
   return number.toLocaleString(navigator.language)
 }
+
+export const secondLevelDrilldownSeriesDataToThirdLevel = (data) => {
+  const mArch = new Map();
+  const mOs = new Map();
+
+  mArch.set('sources', []);
+  mOs.set('sources', []);
+
+  data.forEach((slddsd) => {
+    const tokens = slddsd.name.split('_');
+    // console.info("what = " + tokens[0]);
+    // console.info("arch = " + tokens[1]);
+    // console.info("os = " + tokens[2]);
+    // console.info("hotspot = " + tokens[3]);
+    // console.info("version = " + tokens[4]);
+
+    if(tokens.length === 3 && tokens[0].endsWith("sources")) {
+      mArch.get('sources').push(slddsd);
+      mOs.get('sources').push(slddsd);
+    } else if(tokens.length >= 5) {
+      if(!mArch.has(tokens[1])) mArch.set(tokens[1], []);
+      mArch.get(tokens[1]).push(slddsd);
+
+      if(!mOs.has(tokens[2])) mOs.set(tokens[2], []);
+      mOs.get(tokens[2]).push(slddsd);
+    }
+  });
+
+  if(mArch.get('sources').length === 0) mArch.delete('sources');
+  if(mOs.get('sources').length === 0) mOs.delete('sources');
+
+  return {
+    arch: Object.fromEntries(mArch),
+    os: Object.fromEntries(mOs)
+  };
+}
+
+export const toSecondAndThirdLevels = (data) => {
+  const mArch = new Map();
+  const mOs = new Map();
+
+  mArch.set('sources', {name: 'Sources', id: 'sources', data: []});
+  mOs.set('sources', {name: 'Sources', id: 'sources', data: []});
+
+  data.forEach((slddsd) => {
+    const tokens = slddsd.name.split('_');
+    // console.info("what = " + tokens[0]);
+    // console.info("arch = " + tokens[1]);
+    // console.info("os = " + tokens[2]);
+    // console.info("hotspot = " + tokens[3]);
+    // console.info("version = " + tokens[4]);
+
+    if(tokens.length === 3 && tokens[0].endsWith("sources")) {
+      mArch.get('sources').data.push(slddsd);
+      mOs.get('sources').data.push(slddsd);
+    } else if(tokens.length >= 5) {
+      if(!mArch.has(tokens[1])) mArch.set(tokens[1], {name: tokens[1], id: tokens[1], data: []});
+      mArch.get(tokens[1]).data.push(slddsd);
+
+      if(!mOs.has(tokens[2])) mOs.set(tokens[2], {name: tokens[1], id: tokens[1], data: []});
+      mOs.get(tokens[2]).data.push(slddsd);
+    }
+  });
+
+  if(mArch.get('sources').data.length === 0) mArch.delete('sources');
+  if(mOs.get('sources').data.length === 0) mOs.delete('sources');
+
+  return {
+    arch: Object.fromEntries(mArch),
+    os: Object.fromEntries(mOs)
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,7 @@ const getArtifactAndFormattedName = (entry) => {
     return { artifact: 'sources', name: 'sources' }
   } else if (tokens.length >= 5) {
     const artifact = tokens[0].slice(tokens[0].indexOf('-') + 1)
-    const name = entry.name.endsWith('.msi')
+    const name = (entry.name.endsWith('.msi') || entry.name.endsWith('.pkg'))
       ? `${capitalizeFirst(tokens[2])} (${capitalizeFirst(tokens[1])} / installer)`
       : `${capitalizeFirst(tokens[2])} (${capitalizeFirst(tokens[1])})`
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,48 +32,55 @@ export const formatNum = number => {
 }
 
 export const splitDrilldownSeriesByArchAndOs = (data) => {
-  const mArch = new Map();
-  const mOs = new Map();
+  const mArch = new Map()
+  const mOs = new Map()
 
-  mArch.set('sources', {name: 'Sources', id: 'sources', data: []});
-  mOs.set('sources', {name: 'Sources', id: 'sources', data: []});
+  mArch.set('sources', { name: 'Sources', id: 'sources', data: [] })
+  mOs.set('sources', { name: 'Sources', id: 'sources', data: [] })
 
   data.forEach((slddsd) => {
-    const tokens = slddsd.name.split('_');
+    const tokens = slddsd.name.split('_')
     // console.info("what = " + tokens[0]);
     // console.info("arch = " + tokens[1]);
     // console.info("os = " + tokens[2]);
     // console.info("hotspot = " + tokens[3]);
     // console.info("version = " + tokens[4]);
 
-    slddsd['name'] = getFormattedName(tokens);
+    slddsd.name = getFormattedName(tokens)
 
-    if(tokens.length === 3 && tokens[0].endsWith("sources")) {
-      mArch.get('sources').data.push(slddsd);
-      mOs.get('sources').data.push(slddsd);
-    } else if(tokens.length >= 5) {
-      if(!mArch.has(tokens[1])) mArch.set(tokens[1], {name: tokens[1], id: tokens[1], data: []});
+    if (tokens.length === 3 && tokens[0].endsWith('sources')) {
+      mArch.get('sources').data.push(slddsd)
+      mOs.get('sources').data.push(slddsd)
+    } else if (tokens.length >= 5) {
+      if (!mArch.has(tokens[1])) mArch.set(tokens[1], { name: tokens[1], id: tokens[1], data: [] })
 
-      mArch.get(tokens[1]).data.push(slddsd);
+      mArch.get(tokens[1]).data.push(slddsd)
 
-      if(!mOs.has(tokens[2])) mOs.set(tokens[2], {name: tokens[1], id: tokens[1], data: []});
-      mOs.get(tokens[2]).data.push(slddsd);
+      if (!mOs.has(tokens[2])) mOs.set(tokens[2], { name: tokens[1], id: tokens[1], data: [] })
+      mOs.get(tokens[2]).data.push(slddsd)
     }
-  });
+  })
 
-  if(mArch.get('sources').data.length === 0) mArch.delete('sources');
-  if(mOs.get('sources').data.length === 0) mOs.delete('sources');
+  if (mArch.get('sources').data.length === 0) mArch.delete('sources')
+  if (mOs.get('sources').data.length === 0) mOs.delete('sources')
 
   return {
     arch: Object.fromEntries(mArch),
     os: Object.fromEntries(mOs)
-  };
+  }
 }
 
 const getFormattedName = (tokens) => {
-  if(tokens.length === 3 && tokens[0].endsWith("sources")) return "sources";
-  else if(tokens.length >= 5) {
-    const afterCarret = tokens[0].slice(tokens[0].indexOf('-') + 1);
-    return `${afterCarret} ${tokens[2]}`}
-  else return tokens.join('_')    
+  if (tokens.length === 3 && tokens[0].endsWith('sources')) return 'sources'
+  else if (tokens.length >= 5) {
+    let afterCarret = tokens[0].slice(tokens[0].indexOf('-') + 1)
+    if (afterCarret === 'jre') afterCarret = 'JRE'
+    else if (afterCarret === 'jdk') afterCarret = 'JDK'
+
+    return `${capitalizeFirst(tokens[2])} (${capitalizeFirst(afterCarret)})`
+  } else return tokens.join('_')
+}
+
+const capitalizeFirst = (text) => {
+  return text[0].toUpperCase() + text.substring(1)
 }

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,7 +1,11 @@
 import { vi } from 'vitest'
 import Highcharts from 'highcharts'
+import AccessibilityModule from 'highcharts/modules/accessibility'
+
+AccessibilityModule(Highcharts)
 
 Highcharts.useSerialIds(true);
+Highcharts.AST.allowedAttributes.push('rel');
 
 // mock router for 'useParams'
 vi.mock('react-router-dom');


### PR DESCRIPTION
This PR is a suggestion to the issue #348 

It adds a new level in the drilldown, sorted by 'Package Type' and having simplified names like 'Linux (JDK)'.

Feel free to say that it's not the best solution and you want to split charts another way :smile: 
