### PR TITLE
Bump react-router from 5.3.4 to 6.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
                 "moment": "^2.29.4",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-router": "^5.3.4",
-                "react-router-dom": "^5.3.4",
+                "react-router": "^6.17.0",
+                "react-router-dom": "^6.17.0",
                 "static-server": "^2.2.1",
                 "vitest": "^0.34.6"
             },
@@ -4637,6 +4637,14 @@
                 "react-dom": ">=16.9.0"
             }
         },
+        "node_modules/@remix-run/router": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
+            "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -7278,27 +7286,6 @@
                 "react": ">=16.8.0"
             }
         },
-        "node_modules/history": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-            "dependencies": {
-                "@babel/runtime": "^7.1.2",
-                "loose-envify": "^1.2.0",
-                "resolve-pathname": "^3.0.0",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0",
-                "value-equal": "^1.0.1"
-            }
-        },
-        "node_modules/hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "dependencies": {
-                "react-is": "^16.7.0"
-            }
-        },
         "node_modules/html-encoding-sniffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -8630,14 +8617,6 @@
                 "node": "*"
             }
         },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/object-is": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
@@ -9084,16 +9063,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6.0"
-            }
-        },
-        "node_modules/prop-types": {
-            "version": "15.7.2",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.8.1"
             }
         },
         "node_modules/proxy-addr": {
@@ -9838,11 +9807,6 @@
             "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
             "dev": true
         },
-        "node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
         "node_modules/react-refresh": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
@@ -9853,52 +9817,33 @@
             }
         },
         "node_modules/react-router": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
+            "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
             "dependencies": {
-                "@babel/runtime": "^7.12.13",
-                "history": "^4.9.0",
-                "hoist-non-react-statics": "^3.1.0",
-                "loose-envify": "^1.3.1",
-                "path-to-regexp": "^1.7.0",
-                "prop-types": "^15.6.2",
-                "react-is": "^16.6.0",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0"
+                "@remix-run/router": "1.10.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "react": ">=15"
+                "react": ">=16.8"
             }
         },
         "node_modules/react-router-dom": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
+            "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
             "dependencies": {
-                "@babel/runtime": "^7.12.13",
-                "history": "^4.9.0",
-                "loose-envify": "^1.3.1",
-                "prop-types": "^15.6.2",
-                "react-router": "5.3.4",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0"
+                "@remix-run/router": "1.10.0",
+                "react-router": "6.17.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "react": ">=15"
-            }
-        },
-        "node_modules/react-router/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "node_modules/react-router/node_modules/path-to-regexp": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-            "dependencies": {
-                "isarray": "0.0.1"
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
             }
         },
         "node_modules/redent": {
@@ -10055,11 +10000,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/resolve-pathname": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
         },
         "node_modules/rollup": {
             "version": "3.29.2",
@@ -10451,16 +10391,6 @@
             "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
             "dev": true
         },
-        "node_modules/tiny-invariant": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-            "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-        },
         "node_modules/tinybench": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.1.tgz",
@@ -10708,11 +10638,6 @@
             "engines": {
                 "node": ">=10.12.0"
             }
-        },
-        "node_modules/value-equal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -14076,6 +14001,11 @@
                 "rc-util": "^5.33.0"
             }
         },
+        "@remix-run/router": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
+            "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw=="
+        },
         "@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -16039,27 +15969,6 @@
             "integrity": "sha512-hyQTX7ezCxl7JqumaWiGsroGWalzh24GedQIgO3vJbkGOZ6ySRAltIYjfxhrq4HszJOySZegotEF7v+haQ75UA==",
             "requires": {}
         },
-        "history": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-            "requires": {
-                "@babel/runtime": "^7.1.2",
-                "loose-envify": "^1.2.0",
-                "resolve-pathname": "^3.0.0",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0",
-                "value-equal": "^1.0.1"
-            }
-        },
-        "hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "requires": {
-                "react-is": "^16.7.0"
-            }
-        },
         "html-encoding-sniffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -16953,11 +16862,6 @@
             "optional": true,
             "peer": true
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
         "object-is": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
@@ -17293,16 +17197,6 @@
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
             "dev": true
-        },
-        "prop-types": {
-            "version": "15.7.2",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-            "requires": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.8.1"
-            }
         },
         "proxy-addr": {
             "version": "2.0.7",
@@ -17821,11 +17715,6 @@
             "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
             "dev": true
         },
-        "react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
         "react-refresh": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
@@ -17833,48 +17722,20 @@
             "dev": true
         },
         "react-router": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
+            "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
             "requires": {
-                "@babel/runtime": "^7.12.13",
-                "history": "^4.9.0",
-                "hoist-non-react-statics": "^3.1.0",
-                "loose-envify": "^1.3.1",
-                "path-to-regexp": "^1.7.0",
-                "prop-types": "^15.6.2",
-                "react-is": "^16.6.0",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "path-to-regexp": {
-                    "version": "1.8.0",
-                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-                    "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-                    "requires": {
-                        "isarray": "0.0.1"
-                    }
-                }
+                "@remix-run/router": "1.10.0"
             }
         },
         "react-router-dom": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
+            "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
             "requires": {
-                "@babel/runtime": "^7.12.13",
-                "history": "^4.9.0",
-                "loose-envify": "^1.3.1",
-                "prop-types": "^15.6.2",
-                "react-router": "5.3.4",
-                "tiny-invariant": "^1.0.2",
-                "tiny-warning": "^1.0.0"
+                "@remix-run/router": "1.10.0",
+                "react-router": "6.17.0"
             }
         },
         "redent": {
@@ -17995,11 +17856,6 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
-        },
-        "resolve-pathname": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
         },
         "rollup": {
             "version": "3.29.2",
@@ -18287,16 +18143,6 @@
             "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
             "dev": true
         },
-        "tiny-invariant": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-            "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-        },
-        "tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-        },
         "tinybench": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.1.tgz",
@@ -18468,11 +18314,6 @@
                 "@types/istanbul-lib-coverage": "^2.0.1",
                 "convert-source-map": "^1.6.0"
             }
-        },
-        "value-equal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         },
         "vary": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
         "moment": "^2.29.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router": "^5.3.4",
-        "react-router-dom": "^5.3.4",
+        "react-router": "^6.17.0",
+        "react-router-dom": "^6.17.0",
         "static-server": "^2.2.1",
         "vitest": "^0.34.6"
     },

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Route } from 'react-router'
+import { Routes, Route } from 'react-router'
 import { ConfigProvider, Layout, Menu, Button } from 'antd'
 import Highcharts from 'highcharts'
 import AccessibilityModule from 'highcharts/modules/accessibility'
@@ -55,9 +55,11 @@ export default class App extends Component {
               <ErrorBoundary>
                 <Content style={{ background: '#fff', padding: 24, margin: 0, minHeight: 280 }}>
                   <Button onClick={this.handleToggle} type='link' shape='circle' icon={this.state.collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />} />
-                  <Route exact path='/' component={Download} />
-                  <Route path='/download' component={Download} />
-                  <Route path='/trends' component={Trends} />
+                  <Routes>
+                    <Route exact path='/' element={<Download />} />
+                    <Route path='/download' element={<Download />} />
+                    <Route path='/trends' element={<Trends />} />
+                  </Routes>
                 </Content>
               </ErrorBoundary>
             </Layout>


### PR DESCRIPTION
Bump react-router from 5.3.4 to 6.17.0

Fix this automatic PR that aren't good: 
https://github.com/adoptium/dash.adoptium.net/pull/383
https://github.com/adoptium/dash.adoptium.net/pull/384

Close this PR after.